### PR TITLE
MFD_HSU: Fix bad trace include

### DIFF
--- a/drivers/tty/serial/Makefile
+++ b/drivers/tty/serial/Makefile
@@ -72,6 +72,10 @@ obj-$(CONFIG_SERIAL_GRLIB_GAISLER_APBUART) += apbuart.o
 obj-$(CONFIG_SERIAL_ALTERA_JTAGUART) += altera_jtaguart.o
 obj-$(CONFIG_SERIAL_VT8500) += vt8500_serial.o
 obj-$(CONFIG_SERIAL_MRST_MAX3110)	+= mrst_max3110.o
+
+# trick inspired from net/mac80211/Makefile as suggested on
+# http://lwn.net/Articles/383362/
+CFLAGS_mfd_core.o := -I$(src)
 obj-$(CONFIG_SERIAL_MFD_HSU)	+= mfd_core.o mfd_dma.o mfd_pci.o mfd_plat.o
 obj-$(CONFIG_SERIAL_IFX6X60)  	+= ifx6x60.o
 obj-$(CONFIG_SERIAL_PCH_UART)	+= pch_uart.o


### PR DESCRIPTION
Fixes the indirect inclusion of mfd_trace.h by mfd_core.c.
