### PR TITLE
Fix for missing ./mfd_trace.h and ./trace.h

### DIFF
--- a/drivers/tty/serial/Makefile
+++ b/drivers/tty/serial/Makefile
@@ -78,9 +78,6 @@ obj-$(CONFIG_SERIAL_GRLIB_GAISLER_APBUART) += apbuart.o
 obj-$(CONFIG_SERIAL_ALTERA_JTAGUART) += altera_jtaguart.o
 obj-$(CONFIG_SERIAL_VT8500) += vt8500_serial.o
 obj-$(CONFIG_SERIAL_MRST_MAX3110)	+= mrst_max3110.o
-
-# Fix missing trace.h issue
-CFLAGS_mfd_core.o := -I$(src)
 obj-$(CONFIG_SERIAL_MFD_HSU)	+= mfd_core.o mfd_dma.o mfd_pci.o mfd_plat.o
 obj-$(CONFIG_SERIAL_IFX6X60)  	+= ifx6x60.o
 obj-$(CONFIG_SERIAL_PCH_UART)	+= pch_uart.o

--- a/drivers/tty/serial/Makefile
+++ b/drivers/tty/serial/Makefile
@@ -78,6 +78,9 @@ obj-$(CONFIG_SERIAL_GRLIB_GAISLER_APBUART) += apbuart.o
 obj-$(CONFIG_SERIAL_ALTERA_JTAGUART) += altera_jtaguart.o
 obj-$(CONFIG_SERIAL_VT8500) += vt8500_serial.o
 obj-$(CONFIG_SERIAL_MRST_MAX3110)	+= mrst_max3110.o
+
+# Fix missing trace.h issue
+CFLAGS_mfd_core.o := -I$(src)
 obj-$(CONFIG_SERIAL_MFD_HSU)	+= mfd_core.o mfd_dma.o mfd_pci.o mfd_plat.o
 obj-$(CONFIG_SERIAL_IFX6X60)  	+= ifx6x60.o
 obj-$(CONFIG_SERIAL_PCH_UART)	+= pch_uart.o

--- a/drivers/usb/dwc3/Makefile
+++ b/drivers/usb/dwc3/Makefile
@@ -3,6 +3,9 @@ CFLAGS_trace.o				:= -I$(src)
 
 ccflags-$(CONFIG_USB_DWC3_DEBUG)	:= -DDEBUG
 ccflags-$(CONFIG_USB_DWC3_VERBOSE)	+= -DVERBOSE_DEBUG
+
+# Fix missing trace.h issue
+CFLAGS_dwc3-device-intel.o := -I$(src)
 obj-$(CONFIG_USB_DWC3_DEVICE_INTEL)        += dwc3-device-intel.o
 obj-$(CONFIG_USB_DWC3_INTEL_MRFL)      += dwc3-intel-mrfl.o
 ifneq ($(CONFIG_DEBUG_FS),)


### PR DESCRIPTION
Fix for missing ./mfd_trace.h ./trace.h that lead to compilation termination.
