### PR TITLE
Fix wrong ptrace access perms

### DIFF
--- a/fs/proc/task_mmu.c
+++ b/fs/proc/task_mmu.c
@@ -170,7 +170,7 @@ static void *m_start(struct seq_file *m, loff_t *pos)
 	if (!priv->task)
 		return ERR_PTR(-ESRCH);
 
-	mm = mm_access(priv->task, PTRACE_MODE_READ);
+	mm = mm_access(priv->task, PTRACE_MODE_READ_FSCREDS);
 	if (!mm || IS_ERR(mm))
 		return mm;
 	down_read(&mm->mmap_sem);
@@ -1044,7 +1044,7 @@ static ssize_t pagemap_read(struct file *file, char __user *buf,
 	if (!pm.buffer)
 		goto out_task;
 
-	mm = mm_access(task, PTRACE_MODE_READ);
+	mm = mm_access(task, PTRACE_MODE_READ_FSCREDS);
 	ret = PTR_ERR(mm);
 	if (!mm || IS_ERR(mm))
 		goto out_free;

--- a/fs/proc/task_nommu.c
+++ b/fs/proc/task_nommu.c
@@ -223,7 +223,7 @@ static void *m_start(struct seq_file *m, loff_t *pos)
 	if (!priv->task)
 		return ERR_PTR(-ESRCH);
 
-	mm = mm_access(priv->task, PTRACE_MODE_READ);
+	mm = mm_access(priv->task, PTRACE_MODE_READ_FSCREDS);
 	if (!mm || IS_ERR(mm)) {
 		put_task_struct(priv->task);
 		priv->task = NULL;


### PR DESCRIPTION
I ran into issues while running ```lsof```. Everytime it ran, it yielded a lot of kernel stack traces. The hunt produced a fix over [here](https://github.com/emlid/edison-linux/commit/474d09066b8ba8c4098a00bbb0303f1ba25220ad).

Later I came across that there's already a fix introduced in 3.10.99. As it seems like Intel has abandoned this repository and community is still stuck using non-updated LTS kernels, everyone should see the patch and apply it if need be. It'd be better just to rebase Intel's branch onto 3.10.104 (the latest tag at the time of writing this PR message) in this stable kernel tree rather than cherry-picking commits, though.